### PR TITLE
Time bugs closes #3

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="A Spelling Bee Puzzle Game." />
+    <meta name="keywords" content="spelling bee,free,open source,game,puzzle" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Spelling Bee</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "@vueuse/core": "^8.9.2",
+    "date-fns": "^2.29.2",
     "element-plus": "^2.2.9",
     "pinia": "^2.0.15",
     "sass": "^1.53.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -47,19 +47,7 @@ const onCloseCorrectGuesses = () => {
 
 onMounted(onToggleDarkMode);
 
-// current date yyyy-mm-dd
-const dateString = new Date().toISOString().split("T")[0] as string;
-// current date as int yyyymmdd
-const dateInt = parseInt(dateString.replaceAll("-", ""), 10);
-// pick next puzzle input, % len puzzles to restart if out of index
-const todaysAnswerObj = allAnswers[dateInt % allAnswers.length];
-const yesterdaysAnswerObj = allAnswers[(dateInt - 1) % allAnswers.length];
-// reset old answers if necessary, make answers available in all components
-store.startGame({
-  todaysAnswerObj,
-  yesterdaysAnswerObj,
-  gameDate: dateString,
-});
+store.startGame({ allAnswers });
 // TODO: remove i18n
 // TODO: extra not in spellingbee: track scores across days
 // TODO: add shake animation on incorrect submission?

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,6 +606,11 @@ csstype@^2.6.8:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.20.tgz#9229c65ea0b260cf4d3d997cb06288e36a8d6dda"
   integrity sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==
 
+date-fns@^2.29.2:
+  version "2.29.2"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.2.tgz#0d4b3d0f3dff0f920820a070920f0d9662c51931"
+  integrity sha512-0VNbwmWJDS/G3ySwFSJA3ayhbURMTJLtwM2DTxf9CWondCnh6DTNlO9JgRSq6ibf4eD0lfMJNBxUdEAHHix+bA==
+
 dayjs@^1.11.3:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.3.tgz#4754eb694a624057b9ad2224b67b15d552589258"


### PR DESCRIPTION
1. use datefns to get number of days since epoch. ensures yesterdays answers are always correct at month borders
2. use datefns so users in other localities don't get new puzzles before 12am
3. add  meta tags to index.html