### PR TITLE
schedule merge

### DIFF
--- a/.github/workflows/merge-schedule.yml
+++ b/.github/workflows/merge-schedule.yml
@@ -1,0 +1,33 @@
+# https://github.com/marketplace/actions/merge-schedule
+# https://github.com/gr2m/merge-schedule-action
+name: Merge Schedule
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+  schedule:
+    # https://crontab.guru/every-hour
+    - cron: "0 * * * *"
+
+jobs:
+  merge_schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gr2m/merge-schedule-action@v2
+        with:
+          # Merge method to use. Possible values are merge, squash or
+          # rebase. Default is merge.
+          merge_method: squash
+          # Time zone to use. Default is UTC.
+          # time_zone: 'America/Los_Angeles'
+          # Require all pull request statuses to be successful before
+          # merging. Default is `false`.
+          require_statuses_success: "true"
+          # Label to apply to the pull request if the merge fails. Default is
+          # `automerge-fail`.
+          automerge_fail_label: "merge-schedule-failed"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
add merge schedule github action.
when merge will change game inputs, best to merge near midnight,
to avoid disrupting people mid-game.
yesterdays answers will still be incorrect next day though.

/schedule 2022-09-04T18:00:00.000Z