### PR TITLE
build-cache-bust

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
       output: {
         entryFileNames: `[name]-${dateHash}.js`,
         chunkFileNames: `[name]-${dateHash}.js`,
-        assetFileNames: `[name]-${dateHash}.[ext]`
+        assetFileNames: `[name]-${dateHash}.[ext]`,
       },
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,10 @@ import vue from "@vitejs/plugin-vue";
 import { vueI18n } from "@intlify/vite-plugin-vue-i18n";
 import checker from "vite-plugin-checker";
 
+// https://stackoverflow.com/a/68123263/6305204
+// ensure cache is busted correctly on redeploy
+const dateHash = new Date().toISOString().split("T")[0];
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
@@ -13,4 +17,13 @@ export default defineConfig({
       include: path.resolve(__dirname, "./src/locales/**"),
     }),
   ],
+  build: {
+    rollupOptions: {
+      output: {
+        entryFileNames: `[name]-${dateHash}.js`,
+        chunkFileNames: `[name]-${dateHash}.js`,
+        assetFileNames: `[name]-${dateHash}.[ext]`
+      },
+    },
+  },
 });


### PR DESCRIPTION
add date to build outputs so cache is busted correctly.
previously had issues with browsers caching js, css, favicons etc. too long