### PR TITLE
Fix bug causing games to restart at incorrect times

### DIFF
--- a/test/App.vue.test.js
+++ b/test/App.vue.test.js
@@ -6,14 +6,14 @@ import App from "./src/App.vue";
 config.global.mocks.$t = (v) => v;
 
 describe("App.vue", () => {
-  let testDate = "2023-02-03";
+  const testDate = new Date("2023-02-03");
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.useFakeTimers();
-    vi.setSystemTime(new Date(testDate));
+    vi.setSystemTime(testDate);
   });
-  it("should render the date in the title", () => {
-    const testMessage = `Spelling Bee ${testDate}`;
+  it("should render the local date in the title", () => {
+    const testMessage = `Spelling Bee ${testDate.toLocaleDateString("sv")}`;
     const wrapper = shallowMount(App);
     expect(wrapper.get("#title-header").text()).toBe(testMessage);
   });

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -76,7 +76,7 @@ describe("Store", () => {
       });
       describe("when gameDate is a date", () => {
         it("should get todays and yesterdays answers correctly", () => {
-          store.startGame({ allAnswers });
+          store.startGame({ allAnswers, gameDate });
           expect(store.correctGuesses).toEqual(new Set([]));
           expect(store.answers).toEqual(["felt", "feat", "feet"]);
           expect(store.availableLetters).toEqual("aeflrst");
@@ -89,7 +89,7 @@ describe("Store", () => {
       describe("when gameDate is a string", () => {
         it("should get todays and yesterdays answers correctly", () => {
           store.gameDate = gameDateString;
-          store.startGame({ allAnswers });
+          store.startGame({ allAnswers, gameDate });
           expect(store.correctGuesses).toEqual(new Set([]));
           expect(store.answers).toEqual(["felt", "feat", "feet"]);
           expect(store.availableLetters).toEqual("aeflrst");
@@ -115,7 +115,7 @@ describe("Store", () => {
         store.answers = ["test", "use", "cache"];
         store.middleLetter = "e";
         store.availableLetters = "acehstu";
-        store.startGame({ allAnswers });
+        store.startGame({ allAnswers, gameDate });
         expect(store.correctGuesses).toEqual(new Set([]));
         expect(store.answers).toEqual(["error", "ooze", "otter"]);
         expect(store.availableLetters).toEqual("eioprtz");
@@ -140,7 +140,7 @@ describe("Store", () => {
         store.answers = ["test", "use", "cache"];
         store.middleLetter = "e";
         store.availableLetters = "acehstu";
-        store.startGame({ allAnswers });
+        store.startGame({ allAnswers, gameDate });
         expect(store.correctGuesses).toEqual(new Set([]));
         expect(store.answers).toEqual(["error", "ooze", "otter"]);
         expect(store.availableLetters).toEqual("eioprtz");
@@ -165,7 +165,7 @@ describe("Store", () => {
           store.gameDate = gameDate;
           store.correctGuesses = new Set(["test"]);
           // should exit early
-          expect(store.startGame({ allAnswers })).toEqual(false);
+          expect(store.startGame({ allAnswers, gameDate })).toEqual(false);
           // answers should not be reset to []
           expect(store.correctGuesses).toEqual(new Set(["test"]));
         });
@@ -175,7 +175,7 @@ describe("Store", () => {
           store.gameDate = gameDateString;
           store.correctGuesses = new Set(["test"]);
           // should exit early
-          expect(store.startGame({ allAnswers })).toEqual(false);
+          expect(store.startGame({ allAnswers, gameDate })).toEqual(false);
           // answers should not be reset to []
           expect(store.correctGuesses).toEqual(new Set(["test"]));
         });


### PR DESCRIPTION
Previously the game to be played was determined by using the UTC date at runtime. This was problematic because the UTC date can differ from the user's local date, causing games to switch over at all times of day depending on where in the world the user was located. Now the game to be played is determined by using the local date at runtime and switches over into the next game when the local date changes.

---

Love the game! It's my favorite Spelling Bee clone. I want to help fix this bug because I've been running into it.

Fixes #37 